### PR TITLE
fix: the beEmpty assertion method now validates the response object being null

### DIFF
--- a/src/main/java/info/tomfi/alexa/skillstester/steps/impl/ThenResponseImpl.java
+++ b/src/main/java/info/tomfi/alexa/skillstester/steps/impl/ThenResponseImpl.java
@@ -150,10 +150,7 @@ public final class ThenResponseImpl extends ThenResponse {
 
   @Override
   public ThenResponseImpl beEmpty() {
-    haveNoOutputSpeech();
-    haveNoReprompt();
-    haveNoCard();
-    haveNoSessionAttributes();
+    assert isNull(responseEnvelope.getResponse()) : "Response object is not empty";
     return this;
   }
 

--- a/src/test/java/info/tomfi/alexa/skillstester/steps/impl/Assertion_Method_beEmpty_Test.java
+++ b/src/test/java/info/tomfi/alexa/skillstester/steps/impl/Assertion_Method_beEmpty_Test.java
@@ -17,10 +17,6 @@ import static org.assertj.core.api.BDDAssertions.thenExceptionOfType;
 import static org.mockito.BDDMockito.given;
 
 import com.amazon.ask.model.Response;
-import com.amazon.ask.model.ui.Card;
-import com.amazon.ask.model.ui.OutputSpeech;
-import com.amazon.ask.model.ui.Reprompt;
-import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -29,49 +25,16 @@ import org.mockito.Mock;
 @Tag("unit-tests")
 final class Assertion_Method_beEmpty_Test extends AssertionMethodsFixtures {
   @Test
-  void asserting_with_an_empty_response_will_keep_ongoing_assertion(
-      @Mock final Response response) {
-    given(responseEnvelope.getResponse()).willReturn(response);
+  void asserting_with_a_null_response_object_will_keep_ongoing_assertion() {
     then(sut.beEmpty()).isEqualTo(sut);
   }
 
   @Test
-  void asserting_with_an_existing_output_speech_object_will_throw_an_assertion_error(
-      @Mock final Response response, @Mock final OutputSpeech outputSpeech) {
-    given(response.getOutputSpeech()).willReturn(outputSpeech);
-    given(responseEnvelope.getResponse()).willReturn(response);
-    thenExceptionOfType(AssertionError.class)
-        .isThrownBy(() -> sut.beEmpty())
-        .withMessage("Found output speech object");
-  }
-
-  @Test
-  void asserting_with_an_existing_reprompt_object_will_throw_an_assertion_error(
-      @Mock final Response response, @Mock final Reprompt reprompt) {
-    given(response.getReprompt()).willReturn(reprompt);
-    given(responseEnvelope.getResponse()).willReturn(response);
-    thenExceptionOfType(AssertionError.class)
-        .isThrownBy(() -> sut.beEmpty())
-        .withMessage("Found reprompt object");
-  }
-
-  @Test
-  void asserting_with_an_existing_card_object_will_throw_an_assertion_error(
-      @Mock final Response response, @Mock final Card card) {
-    given(response.getCard()).willReturn(card);
-    given(responseEnvelope.getResponse()).willReturn(response);
-    thenExceptionOfType(AssertionError.class)
-        .isThrownBy(() -> sut.beEmpty())
-        .withMessage("Found card object");
-  }
-
-  @Test
-  void asserting_with_a_non_empty_session_attribute_map_will_throw_an_assertion_error(
+  void asserting_with_an_existing_response_object_will_throw_an_assertion_error(
       @Mock final Response response) {
-    given(responseEnvelope.getSessionAttributes()).willReturn(Map.of("Key1", (Object) "Value1"));
     given(responseEnvelope.getResponse()).willReturn(response);
     thenExceptionOfType(AssertionError.class)
         .isThrownBy(() -> sut.beEmpty())
-        .withMessage("Found session attributes");
+        .withMessage("Response object is not empty");
   }
 }


### PR DESCRIPTION
fix: the beEmpty assertion method now validates the response object being null